### PR TITLE
Update pins_arduino.h added missing closing bracket

### DIFF
--- a/hardware/arduino/variants/zigduino_r2/pins_arduino.h
+++ b/hardware/arduino/variants/zigduino_r2/pins_arduino.h
@@ -84,7 +84,7 @@ const static uint8_t RFRX = 24;
                                 ( ((p) == 20) ? 2 : \
                                 ( ((p) == 26) ? 0 : \
                                 ( ((p) == 36) ? 0 : \
-                                0 ) ) ) ) ) ) ) ) 
+                                0 ) ) ) ) ) ) ) ) )
 
 #ifdef ARDUINO_MAIN
 


### PR DESCRIPTION
This fixes the problem of not being able to import SoftwareSerial